### PR TITLE
Prepare initial release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "main"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: CI
+
+on:
+  schedule:
+    - cron: '0 10 * * 0'  # every Sunday at 10am
+  push:
+    branches:
+      - main
+      - develop
+    tags:
+      - '*.*'
+  pull_request:
+
+env:
+  docker_repository: tschaffter/getdns-stubby
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint Dockerfiles
+      uses: docker://hadolint/hadolint:latest
+      with:
+        entrypoint: hadolint
+        args: Dockerfile
+    - name: Validate docker-compose.yml
+      run: |
+        docker-compose -f docker-compose.yml config >/dev/null
+
+  docker:
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare
+      id: prep
+      run: |
+        DOCKER_IMAGE=${{ env.docker_repository }}
+        VERSION=noop
+        PUSH=false
+        if [ "${{ github.event_name }}" = "schedule" ]; then
+          VERSION=nightly
+          PUSH=true
+        elif [[ $GITHUB_REF == refs/tags/* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/}
+        elif [[ $GITHUB_REF == refs/heads/* ]]; then
+          VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+            VERSION=edge
+            PUSH=true
+          fi
+        elif [[ $GITHUB_REF == refs/pull/* ]]; then
+          VERSION=pr-${{ github.event.number }}
+        fi
+        TAGS="${DOCKER_IMAGE}:${VERSION}"
+        if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          MAJOR=${VERSION%.*}
+          TAGS="$TAGS,${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+          PUSH=true
+        # elif [ "${{ github.event_name }}" = "push" ]; then
+        #   TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+        fi
+        echo ::set-output name=version::${VERSION}
+        echo ::set-output name=tags::${TAGS}
+        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        echo ::set-output name=push::${PUSH}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      if: steps.prep.outputs.push == 'true'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile
+        platforms: linux/amd64
+        push: ${{ steps.prep.outputs.push }}
+        tags: ${{ steps.prep.outputs.tags }}
+        labels: |
+          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+          org.opencontainers.image.source=${{ github.repositoryUrl }}
+          org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+    # - name: Docker Hub Description
+    #   if: steps.prep.outputs.push == 'true'
+    #   uses: peter-evans/dockerhub-description@v2
+    #   with:
+    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+    #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    #     repository: ${{ env.docker_repository }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,32 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '365'
+          issue-exclude-created-before: ''
+          issue-exclude-labels: ''
+          issue-lock-labels: 'locked'
+          issue-lock-comment: >
+            This thread has been automatically locked since there has not been
+            any recent activity after it was closed. Please open a new issue for
+            related bugs.
+          issue-lock-reason: 'resolved'
+          pr-lock-inactive-days: '365'
+          pr-exclude-created-before: ''
+          pr-exclude-labels: 'locked'
+          pr-lock-labels: ''
+          pr-lock-comment: >
+            This thread has been automatically locked since there has not been
+            any recent activity after it was closed. Please open a new issue for
+            related bugs.
+          pr-lock-reason: 'resolved'
+          process-only: ''

--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
 # Stubby
 
+[![GitHub Release](https://img.shields.io/github/release/tschaffter/stubby.svg?include_prereleases&color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/stubby/releases)
+[![GitHub CI](https://img.shields.io/github/workflow/status/tschaffter/stubby/CI.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/stubby/actions)
+[![GitHub License](https://img.shields.io/github/license/tschaffter/stubby.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/stubby/blob/develop/LICENSE)
+[![Docker Pulls](https://img.shields.io/docker/pulls/tschaffter/stubby.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=pulls&logo=docker)](https://hub.docker.com/r/tschaffter/stubby)
+
 Docker image for Stubby
 
 ## Overview
 
+## Versioning
+
+It is recommended to use a tag other than `latest` if you are using this image
+in a production setting. The tags of this image match the version of the
+repository [getdnsapi/getdns] that provides `stubby`.
+
 
 ## Acknowledgments
 
-This Dockerfile is adapted from the repository [yegle/stubby-docker]
+This Dockerfile is adapted from the one available in the repository
+[yegle/stubby-docker].
 
 ## License
 
@@ -17,3 +29,4 @@ This Dockerfile is adapted from the repository [yegle/stubby-docker]
 
 [yegle/stubby-docker]: https://github.com/yegle/stubby-docker
 [Apache License 2.0]: https://github.com/tschaffter/stubby/blob/main/LICENSE
+[getdnsapi/getdns]: https://github.com/getdnsapi/getdns

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Stubby
 
-[![GitHub Release](https://img.shields.io/github/release/tschaffter/stubby.svg?include_prereleases&color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/stubby/releases)
-[![GitHub CI](https://img.shields.io/github/workflow/status/tschaffter/stubby/CI.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/stubby/actions)
-[![GitHub License](https://img.shields.io/github/license/tschaffter/stubby.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/stubby/blob/develop/LICENSE)
-[![Docker Pulls](https://img.shields.io/docker/pulls/tschaffter/stubby.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=pulls&logo=docker)](https://hub.docker.com/r/tschaffter/stubby)
+[![GitHub Release](https://img.shields.io/github/release/tschaffter/getdns-stubby.svg?include_prereleases&color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/getdns-stubby/releases)
+[![GitHub CI](https://img.shields.io/github/workflow/status/tschaffter/getdns-stubby/CI.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/getdns-stubby/actions)
+[![GitHub License](https://img.shields.io/github/license/tschaffter/getdns-stubby.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/tschaffter/getdns-stubby/blob/develop/LICENSE)
+[![Docker Pulls](https://img.shields.io/docker/pulls/tschaffter/getdns-stubby.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=pulls&logo=docker)](https://hub.docker.com/r/tschaffter/getdns-stubby)
 
 Docker image for Stubby
 
@@ -13,8 +13,7 @@ Docker image for Stubby
 
 It is recommended to use a tag other than `latest` if you are using this image
 in a production setting. The tags of this image match the version of the
-repository [getdnsapi/getdns] that provides `stubby`.
-
+repository [getdnsapi/getdns] that includes `stubby`.
 
 ## Acknowledgments
 


### PR DESCRIPTION
The current implementation is centered on the latest release of https://github.com/getdnsapi/getdns, which includes stubby as a git submodule (https://github.com/getdnsapi/stubby). However, the latest release of stubby is more recent than the latest release of getdns.

The reason the current implementation is centered on getdns is because since the latest release of getdns, getdns is using CMake and provides an option to build only stubby. It's easier to build the version of stubby that comes with the latest release of getdns (defined by the reference to the git submodule).

If the build was to be centered on the latest release of stubby:

1. Clone stubby
2. Identify the version of getdns that stubby required. This information can be found in stubby's CMakeLists.txt
3. Clone getdns that corresponds to what stubby needs.
3. Build and install getdns
4. build stubby

```
# Are we being built from getdns? If so, use the build tree getdns.
if (TARGET getdns)
  target_link_libraries(stubby PRIVATE getdns)
else ()
  find_package(Getdns "1.5.0" REQUIRED)
  target_link_libraries(stubby PRIVATE Getdns::Getdns)
endif ()
```

Because stubby's CMakeLists.txt recently support building stubby as part of getdns, I'm continuing to build stubby this way. Because the build is centered on the latest release of `getdns`, I decided to rename this repository `getdns-stubby` and added a note to the README to say that this repository is aligned on the release version of getdns, not stubby.