### PR TITLE
Use single build image to support multi platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.9-slim as stubby
+FROM debian:10.9-slim
 
 ARG GETDNS_VERSION="1.6.0"
 ENV GETDNS_VERSION=${GETDNS_VERSION}
@@ -16,6 +16,7 @@ RUN apt-get update \
         git \
         gpg \
         gpg-agent \
+        gosu \
         libev-dev \
         libevent-dev \
         libssl-dev \
@@ -44,26 +45,7 @@ RUN gpg --import willem.nlnetlabs.nl \
     && strip -s /usr/local/bin/stubby \
     && strip -s /usr/local/lib/libgetdns.so.10
 
-FROM debian:10.9-slim
-
-SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
-
-# hadolint ignore=DL3008
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        gosu \
-        libyaml-dev \
-    && rm -rf \
-        /tmp/* \
-        /var/tmp/* \
-        /var/lib/apt/lists/*
-
-COPY --from=stubby /usr/local/lib/libgetdns.so.10 /lib/x86_64-linux-gnu/
-COPY --from=stubby /usr/local/bin/stubby /bin/
-COPY --from=stubby /usr/local/bin/getdns_server_mon /bin/
 COPY --from=stubby /tmp/getdns/stubby/stubby.yml.example /usr/local/etc/stubby/stubby.yml
-# COPY --from=stubby /usr/lib/x86_64-linux-gnu/libyaml-0.so.2 /lib/x86_64-linux-gnu/
 
 RUN adduser --system --no-create-home stubby
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ RUN gpg --import willem.nlnetlabs.nl \
     && strip -s /usr/local/bin/stubby \
     && strip -s /usr/local/lib/libgetdns.so.10
 
-COPY --from=stubby /tmp/getdns/stubby/stubby.yml.example /usr/local/etc/stubby/stubby.yml
-
 RUN adduser --system --no-create-home stubby
 
 WORKDIR /


### PR DESCRIPTION
Fixes #7 

The previous approach had a platform-depend value hardcoded in the Dockerfile, which made the image not compatible with multiplatform build. In this approach, I use a single build image, which will lead to a larger image. A two-image build to minimize the size of the image can be investigated again later if the new size is much larger than the previous image.