### PR TITLE
Run c_rehash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ RUN apt-get update \
         # dns-root-data \
         gosu \
         libyaml-0-2 \
+    # Fix https://github.com/tschaffter/getdns-stubby/issues/7#issuecomment-846693585
+    && c_rehash \
     && rm -rf \
         /tmp/* \
         /var/tmp/* \


### PR DESCRIPTION
Fixes #7

Run `c_rehash` to generate the missing root certificates.